### PR TITLE
 Alteração do tipo dos atributos no esqueleto emailSender primitive para o tipo wrapper

### DIFF
--- a/ta-server/EmailSender.ts
+++ b/ta-server/EmailSender.ts
@@ -1,6 +1,6 @@
 export class EmailSender {
   
-  enviarEmail(from: string, to: string, subject: string, message: string): boolean {
+  enviarEmail(from: String, to: String, subject: String, message: String): boolean {
     return true;
   }
 


### PR DESCRIPTION
Alterei o tipos dos campos de string pra String porque o atributo de aluno que passamos para o envio de email está em String, então para não alterar os outros esqueletos e como só eu vou utilizar esse esqueleto (além de não ter problema pois ainda estou no início da funcionalidade de notificação), acho melhor alterar.